### PR TITLE
Remove "cannot open more windows"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ existing `window.open()` API, with some differences:
 - The website cannot set the position of the PiP window.
 - The PiP window cannot be navigated (any `window.history` or `window.location`
     calls that change to a new document will close the PiP window).
-- The PiP window cannot open more windows.
 - The website can have only one PiP window open at a time, and the user agent
   may also restrict how many PiP windows can be open globally, similar to
   `HTMLVideoElement.requestPictureInPicture()` API.

--- a/spec.bs
+++ b/spec.bs
@@ -36,7 +36,6 @@ differences:
 - The website cannot set the position of the PiP window.
 - The PiP window cannot be navigated (any `window.history` or `window.location`
     calls that change to a new document will close the PiP window).
-- The PiP window cannot open more windows.
 
 # Dependencies # {#dependencies}
 


### PR DESCRIPTION
This text is obsolete and no longer needed. Fixes #67 