### PR TITLE
Use [SecureContext] for DocumentPictureInPictureEvent

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -109,7 +109,7 @@ dictionary DocumentPictureInPictureOptions {
   [EnforceRange] unsigned long long height = 0;
 };
 
-[Exposed=Window]
+[Exposed=Window, SecureContext]
 interface DocumentPictureInPictureEvent : Event {
   constructor(DOMString type, DocumentPictureInPictureEventInit eventInitDict);
   [SameObject] readonly attribute Window window;


### PR DESCRIPTION
This event can only be fired if `documentPictureInPicture.requestWindow()` is called, and that's behind `[SecureContext]` for both the `documentPictureInPicture` attribute and the `DocumentPictureInPicture` interface.