### PR TITLE
Use pagehide instead of unload in JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ async function enterPiP() {
   pipWindow.document.body.append(player);
 
   // Listen for the PiP closing event to put the video back.
-  pipWindow.addEventListener("unload", onLeavePiP.bind(pipWindow), {
+  pipWindow.addEventListener("pagehide", onLeavePiP.bind(pipWindow), {
     once: true,
   });
 }
@@ -185,7 +185,7 @@ pipWindow.close();
 When the PiP window is closed for any reason (either because the website
 initiated it or the user closed it), the website will often want to get the
 elements back out of the PiP window. The website can perform this in an event
-handler for the `unload` event on the `Window` object. This is shown in the
+handler for the `pagehide` event on the `Window` object. This is shown in the
 `onLeavePiP()` handler in [Example code](#example-code) section above and is
 copied below:
 

--- a/spec.bs
+++ b/spec.bs
@@ -420,7 +420,7 @@ function enterPiP() {
     pipWindow.document.body.append(player);
 
     // Listen for the PiP closing event to put the video back.
-    pipWindow.addEventListener('unload', onLeavePiP.bind(pipWindow), { once: true });
+    pipWindow.addEventListener('pagehide', onLeavePiP.bind(pipWindow), { once: true });
   });
 }
 
@@ -483,7 +483,7 @@ pipWindow.close();
 When the PiP window is closed for any reason (either because the website
 initiated it or the user closed it), the website will often want to get the
 elements back out of the PiP window. The website can perform this in an event
-handler for the {{Window/unload}} event on the
+handler for the {{Window/pagehide}} event on the
 {{Window}} object. This is shown in the
 <code>onLeavePiP()</code> handler in
 <a href="#example-video-player">video player example</a> above and is copied


### PR DESCRIPTION
As noted in https://groups.google.com/a/chromium.org/g/blink-dev/c/JTPl7fM64Lc, we should use "pagehide" not "unload" JS event to monitor when PiP window gets closed. This PR updates JS examples.

@steimelchrome  Please review