### PR TITLE
Add option to hide the "Back to Tab" button

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -230,7 +230,7 @@ button for the user to return to the original tab and close the
 picture-in-picture window. While this actino makes sense in most cases
 (especially for a video picture-in-picture window that returns the video to the
 main document), it does not always make sense for document picture-in-picture
-windows. {{DocumentPictureInPictureOptions\allowReturnToTab}} is a hint to the
+windows. {{DocumentPictureInPictureOptions/allowReturnToTab}} is a hint to the
 user agent from the website as to whether that action makes sense for their
 particular document picture-in-picture experience.
 </p>
@@ -663,7 +663,7 @@ While user agents often display a button on their video and document
 picture-in-picture windows to return to the original tab and close the window,
 this button doesn't always make sense for some websites' document
 picture-in-picture experience. Use the
-{{DocumentPictureInPictureOptions\allowReturnToTab}} option to hide the button.
+{{DocumentPictureInPictureOptions/allowReturnToTab}} option to hide the button.
 
 <pre class="lang-javascript">
 documentPictureInPicture.requestWindow({ allowReturnToTab: false });

--- a/spec.bs
+++ b/spec.bs
@@ -114,6 +114,7 @@ interface DocumentPictureInPicture : EventTarget {
 dictionary DocumentPictureInPictureOptions {
   [EnforceRange] unsigned long long width = 0;
   [EnforceRange] unsigned long long height = 0;
+  boolean allowReturnToTab = true;
 };
 
 [Exposed=Window, SecureContext]
@@ -218,16 +219,32 @@ problems.
         window such that the distance between the top and bottom edges of the
         viewport are |options|["{{DocumentPictureInPictureOptions/height}}"]
         pixels.
-14. Configure |pip traversable|'s <a>active browsing context</a>'s window to
+14. If |options|["{{DocumentPictureInPictureOptions/allowReturnToTab}}"] exists
+    and is <code>false</code>, the user agent should not display UI affordances
+    on the picture-in-picture window that allow the user to return to the
+    opener window.
+
+<p class="note">
+For both video and document picture-in-picture, user agents often display a
+button for the user to return to the original tab and close the
+picture-in-picture window. While this actino makes sense in most cases
+(especially for a video picture-in-picture window that returns the video to the
+main document), it does not always make sense for document picture-in-picture
+windows. {{DocumentPictureInPictureOptions\allowReturnToTab}} is a hint to the
+user agent from the website as to whether that action makes sense for their
+particular document picture-in-picture experience.
+</p>
+
+15. Configure |pip traversable|'s <a>active browsing context</a>'s window to
     float on top of other windows.
-15. Set <a>this</a>'s <a>last-opened window</a> to |pip traversable|'s <a>active window</a>.
-16. <a>Queue a global task</a> on the
+16. Set <a>this</a>'s <a>last-opened window</a> to |pip traversable|'s <a>active window</a>.
+17. <a>Queue a global task</a> on the
     <a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/webappapis.html#dom-manipulation-task-source">DOM manipulation task source</a>
     given <a>this</a>'s <a>relevant global object</a> to <a>fire an event</a>
     named {{enter}} using {{DocumentPictureInPictureEvent}} on
     <a>this</a> with its {{DocumentPictureInPictureEvent/window}} attribute
     initialized to |pip traversable|'s <a>active window</a>.
-17. Return |pip traversable|'s <a>active window</a>.
+18. Return |pip traversable|'s <a>active window</a>.
 
 </div>
 

--- a/spec.bs
+++ b/spec.bs
@@ -657,6 +657,18 @@ content in question inside the PiP window:
 }
 </pre>
 
+## Hide return-to-tab button ## {#example-hide-return-to-tab}
+
+While user agents often display a button on their video and document
+picture-in-picture windows to return to the original tab and close the window,
+this button doesn't always make sense for some websites' document
+picture-in-picture experience. Use the
+{{DocumentPictureInPictureOptions\allowReturnToTab}} option to hide the button.
+
+<pre class="lang-javascript">
+documentPictureInPicture.requestWindow({ allowReturnToTab: false });
+</pre>
+
 # Acknowledgments # {#acknowledgments}
 
 Many thanks to Frank Liberato, Mark Foltz, Klaus Weidner, François Beaufort,


### PR DESCRIPTION
This adds a new `allowReturnToTab` option that, when false, hints to the user agent that a button for returning to the original tab does not make sense for the website's document picture-in-picture experience.

Fixes #113 