### PR TITLE
Propagate user activation to the opener window

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -478,6 +478,72 @@ write specific CSS rules that are only applied when (part of the) the web app is
 picture-in-picture mode.
 </p>
 
+## User activation propagation ## {#user-activation-propagation}
+
+<p>
+Due to the nature of document picture-in-picture windows, event handlers on
+buttons within the window often end up actually running in the opener's context.
+This can make it unergonomic for websites to call
+<a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-consuming-api">activation consuming APIs</a>,
+since sometimes the document
+picture-in-picture window has <a>transient activation</a> while the opener does
+not.
+
+To make this easier, we will update the
+<a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification">activation notification</a>
+steps to also trigger user activation in the opener when triggering user
+activation in a document picture-in-picture window.
+</p>
+
+<p class="issue">
+Merge this into
+<a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification">activation notification</a>
+steps once it has enough consensus.
+</p>
+
+Add a new step to
+<a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification">activation notification</a>
+after step 3, "<a>Extend</a>
+|windows| with the <a>active window</a> of each of |document|'s
+<a>ancestor navigables</a>.":
+
+4. If |document|'s <a>node navigable</a>'s <a>top-level traversable</a>'s
+    <a>Is Document Picture-in-Picture</a> boolean is <code>true</code>, then
+    <a>extend</a> |windows| with |document|'s <a>node navigable</a>'s
+    <a>top-level traversable</a>'s <a>active browsing context</a>'s
+    <a>opener browsing context</a>'s <a>active window</a>.
+
+<p>
+Additionally, we need to make sure that this activation is properly consumed so
+it can't be used twice (once in the opener and once in the picture-in-picture
+window). We do this by adding steps to <a>consume user activation</a> which
+consume user activation from the opener when consuming a picture-in-picture
+window's user activation, and consuming an associated picture-in-picture
+window's user activation when consuming an opener's user activation.
+</p>
+
+<p class="issue">
+Merge this into <a>consume user activation</a> steps once it has enough
+consensus.
+</p>
+
+Add three new steps to <a>consume user activation</a> after step 3, "Let
+|navigables| be the <a>inclusive descendant navigables</a> of |top|'s
+<a>active document</a>.":
+
+4. If |top|'s <a>Is Document Picture-in-Picture</a> boolean is
+    <code>true</code>, then <a>extend</a> |navigables| with the
+    <a>inclusive descendant navigables</a> of |top|'s
+    <a>active browsing context</a>'s <a>opener browsing context</a>'s
+    <a>active document</a>.
+
+5. Let |document picture-in-picture window| be |top|'s <a>active window</a>'s
+    <a>documentPictureInPicture API</a>'s <a>last-opened window</a>.
+
+6. If |document picture-in-picture window| is not <code>null</code> then
+    <a>extend</a> |navigables| with the <a>inclusive descendant navigables</a>
+    of |document picture-in-picture window|'s <a>associated document</a>.
+
 # Examples # {#examples}
 
 <em>This section is non-normative</em>

--- a/spec.bs
+++ b/spec.bs
@@ -474,7 +474,7 @@ picture-in-picture window after focusing, they can always do so using
 ## CSS display-mode ## {#css-display-mode}
 
 <p>
-The CSS display mode media feature [=display mode/picture-in-picture=] lets web developers
+The CSS display mode media feature ''@media/display-mode/picture-in-picture'' lets web developers
 write specific CSS rules that are only applied when (part of the) the web app is shown in
 picture-in-picture mode.
 </p>

--- a/spec.bs
+++ b/spec.bs
@@ -12,6 +12,7 @@ Abstract: in an always-on-top window.
 </pre>
 
 <pre class="link-defaults">
+spec:dom; type:dfn; text:origin
 spec:html; type:dfn; for:navigable; text:top-level traversable
 spec:html; type:dfn; for:Window; text:navigable
 spec:url; type:dfn; for:/; text:url
@@ -492,7 +493,10 @@ not.
 To make this easier, we will update the
 <a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification">activation notification</a>
 steps to also trigger user activation in the opener when triggering user
-activation in a document picture-in-picture window.
+activation in a document picture-in-picture window. Additionally, when user
+activation is triggered in the opener, we will activate same-origin frames
+insides the document picture-in-picture window, similar to how same-origin
+descendant frames are activated.
 </p>
 
 <p class="issue">
@@ -501,17 +505,31 @@ Merge this into
 steps once it has enough consensus.
 </p>
 
-Add a new step to
+Add three new steps to
 <a href="https://html.spec.whatwg.org/multipage/interaction.html#activation-notification">activation notification</a>
-after step 3, "<a>Extend</a>
+after step 4, "<a>Extend</a>
 |windows| with the <a>active window</a> of each of |document|'s
-<a>ancestor navigables</a>.":
+<a>descendant navigables</a>, filtered to include only those <a>navigables</a>
+whose <a>active document</a>'s <a>origin</a> is <a>same origin</a> with
+|document|'s <a>origin</a>":
 
-4. If |document|'s <a>node navigable</a>'s <a>top-level traversable</a>'s
+5. If |document|'s <a>node navigable</a>'s <a>top-level traversable</a>'s
     <a>Is Document Picture-in-Picture</a> boolean is <code>true</code>, then
     <a>extend</a> |windows| with |document|'s <a>node navigable</a>'s
     <a>top-level traversable</a>'s <a>active browsing context</a>'s
     <a>opener browsing context</a>'s <a>active window</a>.
+
+6. Let |document picture-in-picture window| be |document|'s <a>node navigable</a>'s
+    <a>top-level traversable</a>'s <a>active window</a>'s
+    <a>documentPictureInPicture API</a>'s <a>last-opened window</a>.
+
+7. If |document picture-in-picture window| is not <code>null</code> then
+    <a>extend</a> |windows| with the <a>active window</a> of each of
+    |document picture-in-picture window|'s <a>associated document</a>'s
+    <a>descendant navigables</a>, filtered to include only those
+    <a>navigables</a> whose <a>active document</a>'s <a>origin</a> is
+    <a>same origin</a> with |document picture-in-picture window|'s
+    <a>associated document</a>'s <a>origin</a>.
 
 <p>
 Additionally, we need to make sure that this activation is properly consumed so


### PR DESCRIPTION
This makes user activations in the document picture-in-picture window usable inside the opener window. This makes it more ergonomic to use user-activation-gated APIs, since often event handlers in the document PiP window are actually run in the opener's context, so the opener's context needs access to the user gesture.