### PR TITLE
Add disallowPositionReuse

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -115,6 +115,7 @@ dictionary DocumentPictureInPictureOptions {
   [EnforceRange] unsigned long long width = 0;
   [EnforceRange] unsigned long long height = 0;
   boolean disallowReturnToOpener = false;
+  boolean disallowPositionReuse = false;
 };
 
 [Exposed=Window, SecureContext]
@@ -668,6 +669,24 @@ button.
 
 <pre class="lang-javascript">
 documentPictureInPicture.requestWindow({ disallowReturnToOpener: true });
+</pre>
+
+## Disallow position reuse ## {#example-disallow-position-reuse}
+
+While a document picture-in-picture window is open, the user may choose
+to resize or reposition it. If the document picture-in-picture window is
+closed, then reopened later, the user agent may use the previous position
+and size as a hint for where to place the new window.
+
+The site can provide a hint to the user agent that reusing the previous
+document picture-in-picture window position and size is not desirable
+by setting the {{DocumentPictureInPictureOptions/disallowPositionReuse}}
+option.  For example, if the site is requesting the new document picture-in-
+picture window for an unrelated activity from the previous one, then the site
+could provide this hint to the user agent.
+
+<pre class="lang-javascript">
+documentPictureInPicture.requestWindow({ disallowPositionReuse: true });
 </pre>
 
 # Acknowledgments # {#acknowledgments}


### PR DESCRIPTION
A UA is free to select a position and size for a document PiP window that does not conform to the size requested by the site with `requestWindow()`.  A typical use is to allow user resizes to take precedence if a PiP window is closed and reopened later by the same site, so that the user's preference takes precedence.

This change adds the `disallowPositionReuse` flag to notify the user agent that this PiP window is semantically unrelated to the previous one, so ignoring the most recent user-selected size might be more appropriate, as if this were the first PiP window opened by the site.